### PR TITLE
Updates website url to have https

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 - Mac app evangelist.
 - Swift & Swift UI enthusiast.
 
-Read my blog posts at [https://troz.net](troz.net)
+Read my blog posts at [https://troz.net](https://troz.net)
 Follow me on [Twitter](https://twitter.com/trozware) or on [dev.to](https://dev.to/trozware)


### PR DESCRIPTION
I had this issue on my own repo where not putting the protocol caused the link to try to link to GitHub.